### PR TITLE
Restrict plate types and fix tab check in UI

### DIFF
--- a/src/import_lumifile.R
+++ b/src/import_lumifile.R
@@ -343,6 +343,10 @@ output$segment_selector <- renderUI({
     unique() -> unique_types
 
   unique_types <- c("P", unique_types)
+  # only handle the allowed types
+  allowed_types <- c("P", "X", "S", "C", "B")
+  unique_types <- unique_types[!is.na(unique_types) & unique_types %in% allowed_types]
+
   unique_plate_types(unique_types)
 
  if (!type_p_completed()) {

--- a/src/segment_reader.R
+++ b/src/segment_reader.R
@@ -274,6 +274,7 @@ observe({
 
     type_vector <- unique_plate_types()
 
+
     create_ui_output <- function(type) {
       output_name <- paste0("ui_", type)
       output[[output_name]] <- renderUI({

--- a/src/study_configuration_ui.R
+++ b/src/study_configuration_ui.R
@@ -1464,7 +1464,7 @@ output$user_parameter_download_handle <-  downloadHandler(
     paste(input$readxMap_study_accession, "study_config", currentuser(), ".csv", sep = "_")
   },
   content = function(file) {
-    req(input$main_tabs == "view_files_tab")
+    req(input$main_tabs == "study_settings")
     req(input$readxMap_study_accession)
     req(currentuser())
 


### PR DESCRIPTION
Limits selectable plate types to allowed values in import_lumifile.R,  and corrects the tab check for user parameter download in study_configuration_ui.R to use 'study_settings' instead of 'view_files_tab'.