### PR TITLE
Remove Collapsable Panels for summary statistic tables

### DIFF
--- a/src/bead_count_analysis_ui.R
+++ b/src/bead_count_analysis_ui.R
@@ -97,17 +97,18 @@ beadCountModuleUI <- function(id) {
         ),
         plotlyOutput(ns("beadCountPlot"), width = "75vw"),
         br(),
-        div(
-          class = "bead-count-collapse-container",
-        bsCollapse(
-          id = ns("sample_bead_count_collapse"),
-          bsCollapsePanel(
-            title = "Samples with low Bead Counts",
-            div(style = "overflow-x: auto; width: 100%;",tableOutput(ns("sample_low_bead_count_table"))),
-            style = "primary"
-          )
-        )
-        ),
+        div(style = "overflow-x: auto; width: 100%;",tableOutput(ns("sample_low_bead_count_table"))),
+        # div(
+        #   class = "bead-count-collapse-container",
+        # bsCollapse(
+        #   id = ns("sample_bead_count_collapse"),
+        #   bsCollapsePanel(
+        #     title = "Samples with low Bead Counts",
+        #     div(style = "overflow-x: auto; width: 100%;",tableOutput(ns("sample_low_bead_count_table"))),
+        #     style = "primary"
+        #   )
+        # )
+        # ),
         #div(style = "overflow-x: auto; width: 100%;",tableOutput("sample_low_bead_count_table")),
         br(),
         #uiOutput(ns("download_bead_gating"))

--- a/src/dilutional_linearity_ui.R
+++ b/src/dilutional_linearity_ui.R
@@ -326,16 +326,17 @@ dilutionalLinearityServer <- function(id, selected_study, selected_experiment, c
       if (is.null(plate_lm_facets())) {
         return(NULL)
       } else {
-      div(class = "dilutional_linearity-collapse-container",
-          bsCollapse(
-            id = ns("linearity_stats"),
-            bsCollapsePanel(
-              title = "Summary Statistics",
-              div(class = "table-container", tableOutput(ns("facet_model_glance"))),
-              style = "primary"
-            )
-          )
-      )
+        div(class = "table-container", tableOutput(ns("facet_model_glance")))
+      # div(class = "dilutional_linearity-collapse-container",
+      #     bsCollapse(
+      #       id = ns("linearity_stats"),
+      #       bsCollapsePanel(
+      #         title = "Summary Statistics",
+      #         div(class = "table-container", tableOutput(ns("facet_model_glance"))),
+      #         style = "primary"
+      #       )
+      #     )
+      # )
       }
     })
 

--- a/src/standardcurveui.R
+++ b/src/standardcurveui.R
@@ -113,28 +113,32 @@ The information icon below the figure provides definitions for terminology and a
                # Save Model Fits
                uiOutput(ns("saveButtonsUI")),
                br(),
-              div(class = "standard-curve_model-fit-collapse-container",
-               bsCollapse(
-                 id = ns("standard_curve_model_fit"),
-                 bsCollapsePanel(
-                   title = "Parameter Estimates and Summary Statistics",
-                   div(class = "table-container", tableOutput(ns("parameterFit"))),
-                   div(class = "table-container", tableOutput(ns("modelFit"))),
-                   style = "primary"
-                 )
-               )
-               ),
-              div(class = "gated-samples-collapse-container",
-               bsCollapse(
-                 id = ns("gated_samples"),
-                 bsCollapsePanel(
-                   title = "Gated Samples",
-                   div(class = "table-container",tableOutput(ns("above_ulod_table"))),
-                   div(class = "table-container",tableOutput(ns("below_limit_table"))),
-                   style = "primary"
-                 )
-               )
-              )
+              div(class = "table-container", tableOutput(ns("parameterFit"))),
+              div(class = "table-container", tableOutput(ns("modelFit"))),
+              # div(class = "standard-curve_model-fit-collapse-container",
+              #  bsCollapse(
+              #    id = ns("standard_curve_model_fit"),
+              #    bsCollapsePanel(
+              #      title = "Parameter Estimates and Summary Statistics",
+              #      div(class = "table-container", tableOutput(ns("parameterFit"))),
+              #      div(class = "table-container", tableOutput(ns("modelFit"))),
+              #      style = "primary"
+              #    )
+              #  )
+              #  ),
+              div(class = "table-container",tableOutput(ns("above_ulod_table"))),
+              div(class = "table-container",tableOutput(ns("below_limit_table")))
+              #div(class = "gated-samples-collapse-container",
+               # bsCollapse(
+               #   id = ns("gated_samples"),
+               #   bsCollapsePanel(
+               #     title = "Gated Samples",
+               #     div(class = "table-container",tableOutput(ns("above_ulod_table"))),
+               #     div(class = "table-container",tableOutput(ns("below_limit_table"))),
+               #     style = "primary"
+               #   )
+               # )
+              #)
              )
       )
     )
@@ -817,7 +821,8 @@ standardCurveFittingServer <- function(id, selected_study, selected_experiment, 
         fit_table <- as.data.frame(fit_table)
 
         fit_table
-      })
+      }, caption= "Parameter Estimates",
+      caption.placement = getOption("xtable.caption.placement", "top"))
 
       # Model Fit for saving UI
       output$modelFitUI <- renderUI({
@@ -838,7 +843,8 @@ standardCurveFittingServer <- function(id, selected_study, selected_experiment, 
         model_fit_tab <- mod[2]
         model_fit_tab <- as.data.frame(model_fit_tab)
         model_fit_tab
-      })
+      },caption= "Summary Statistics",
+      caption.placement = getOption("xtable.caption.placement", "top"))
 
 
       # Sample values above ULOD table


### PR DESCRIPTION
Replaced bsCollapse collapsible panels with direct table outputs in bead count analysis, dilutional linearity, and standard curve UI modules to prevent long loading times.