### PR TITLE
Add antigen family row creation and dropdown edit

### DIFF
--- a/src/load_previous_stored_data.R
+++ b/src/load_previous_stored_data.R
@@ -415,6 +415,9 @@ observeEvent(list(input$readxMap_experiment_accession, refresh_data_trigger()), 
       stored_plates_data$stored_samplew <- wide_sample
     }
   }
+  # Update the experiment in antigen family
+  create_antigen_family_rows(input$readxMap_study_accession, input$readxMap_experiment_accession)
+
   remove_modal_progress(session = getDefaultReactiveDomain())
 
   updateTabsetPanel(session, inputId = "inLoadedData", selected = "Data")

--- a/src/standard_curve_summary_ui.R
+++ b/src/standard_curve_summary_ui.R
@@ -279,6 +279,15 @@ observeEvent(list(
       standard_data_curve$selected_str <- paste0(standard_data_curve$study_accession, standard_data_curve$experiment_accession)
       standard_data_curve <- standard_data_curve[standard_data_curve$selected_str == paste0(selected_study, selected_experiment), ]
 
+      # filter antigen family table to the selected experiment if experiment_accession is not NA in antigen family table
+      #if (!any(is.na(antigen_families$experiment_accession))) {
+      # ant_family <<- antigen_families
+      # selected_experiment <<- selected_experiment
+      antigen_families$experiment_accession <- trimws(antigen_families$experiment_accession)
+      antigen_families <- antigen_families[antigen_families$experiment_accession == selected_experiment, ]
+      #}
+
+
       # Summarize std curve data data
       cat("View Standard Curve data plateid")
       print(table(standard_data_curve$plateid))
@@ -290,7 +299,7 @@ observeEvent(list(
       std_curve_data$subject_accession <- std_curve_data$patientid
 
       std_curve_data <- calculate_log_dilution(std_curve_data)
-      std_curve_data <- assign_antigen_families(standard_curve_study_data = std_curve_data, antigen_family_lookup = antigen_families )
+      std_curve_data <- assign_antigen_families(standard_curve_study_data = std_curve_data, antigen_family_lookup = antigen_families)
     }
 
     ## Load study configuration for the user

--- a/src/study_configuration_ui.R
+++ b/src/study_configuration_ui.R
@@ -130,10 +130,42 @@ observeEvent(input$antigen_family_table_cell_edit, {
     }, error = function(e) {
       showNotification(paste("Error updating l_asy_max_constraint:", e$message), type = "error")
     })
-  } else if (col_name == "l_asy_constraint_method") {
+   }
+  #else if (col_name == "l_asy_constraint_method") {
+  #   new_value <- as.character(new_value)
+  #   update_query <- "UPDATE madi_results.xmap_antigen_family
+  #                    SET l_asy_constraint_method = $1 WHERE xmap_antigen_family_id = $2"
+  #
+  #   tryCatch({
+  #     dbExecute(conn, update_query, params = list(new_value, row_id))
+  #     current_data$l_asy_constraint_method[row_num] <- new_value
+  #     antigen_families_rv(current_data)
+  #     showNotification("l_asy_constraint_method updated successfully", type = "message")
+  #   }, error = function(e) {
+  #     showNotification(paste("Error updating l_asy_constraint_method:", e$message), type = "error")
+  #   })
+  # }
+})
+
+observeEvent(input$antigen_family_dropdown_edit, {
+  info <- input$antigen_family_dropdown_edit
+ # info_1 <<- info
+  row_num <- info$row
+  col_num <- info$col
+  new_value <- info$value
+
+  current_data <- antigen_families_rv()
+  #current_data2 <<- current_data
+  col_name <- colnames(current_data)[col_num]
+  row_id <- current_data$xmap_antigen_family_id[row_num]
+  #
+  if (col_name == "l_asy_constraint_method") {
     new_value <- as.character(new_value)
-    update_query <- "UPDATE madi_results.xmap_antigen_family
-                     SET l_asy_constraint_method = $1 WHERE xmap_antigen_family_id = $2"
+    update_query <- "
+      UPDATE madi_results.xmap_antigen_family
+      SET l_asy_constraint_method = $1
+      WHERE xmap_antigen_family_id = $2
+    "
 
     tryCatch({
       dbExecute(conn, update_query, params = list(new_value, row_id))
@@ -143,9 +175,8 @@ observeEvent(input$antigen_family_table_cell_edit, {
     }, error = function(e) {
       showNotification(paste("Error updating l_asy_constraint_method:", e$message), type = "error")
     })
-  }
+   }
 })
-
 # observeEvent(input$antigen_family_table_cell_edit, {
 #   info <- input$antigen_family_table_cell_edit
 #   row_num <- info$row
@@ -463,15 +494,15 @@ render_study_parameters <- reactive({
               selection = 'none',
               class = 'cell-border stripe hover',  # Added styling classes
               callback = JS("
-    $(document).on('change', 'table select', function() {
-      var tbl = $('#antigen_family_table').DataTable();
+    $(document).on('change', '#antigen_family_table table select', function() {
+      var tbl = $('#antigen_family_table table').DataTable();
       var cell = tbl.cell($(this).closest('td'));
       var rowIndex = cell.index().row;
       var colIndex = cell.index().column;
       var value = $(this).val();
       Shiny.setInputValue('antigen_family_dropdown_edit', {
         row: rowIndex + 1,
-        col: colIndex + 1,
+        col: colIndex,
         value: value,
         rand: Math.random()
       });

--- a/src/ui_handler.R
+++ b/src/ui_handler.R
@@ -559,8 +559,8 @@ output$dynamic_data_ui <- renderUI({
         title = "Plates",
         DT::dataTableOutput("stored_header"),
         downloadButton("download_stored_header"),
-        uiOutput("header_actions"),
-        uiOutput("split_button_ui")
+        uiOutput("header_actions")
+       # uiOutput("split_button_ui")
       ),
       tabPanel(
         title = "Standards",


### PR DESCRIPTION
Introduces create_antigen_family_rows to copy template antigen family rows for new experiments and calls it during experiment data load. Adds support for editing l_asy_constraint_method via dropdown, with a new observer and JS callback. Also removes split_button_ui from the Plates tab UI.