### PR TITLE
Improve radio-card spacing and add plate selector

### DIFF
--- a/src/app.R
+++ b/src/app.R
@@ -225,14 +225,19 @@ body <- dashboardBody(
         min-width:370px           !important;   /* browsers that ignore flex‑basis */
         margin:0                  !important;
       }
-
+      
     /* Hide default spacing */
     .radio-card-group .shiny-options-group .radio label{
       width:100%                !important;
       cursor:pointer            !important;
       display:block             !important;
+      margin-bottom: 15px       !important;
     }
 
+.radio-card-group > .form-group > label {
+  display: block;
+  margin-bottom: 14px;  /* increase this as needed */
+}
 
     /* Card styling */
         .radio-card{
@@ -243,6 +248,7 @@ body <- dashboardBody(
       transition:all .2s ease;
       display:flex;
       flex-direction:column;
+      justify-content:space-between;
     }
 
     .radio-card:hover {

--- a/src/std_curver_ui.R
+++ b/src/std_curver_ui.R
@@ -853,7 +853,7 @@ observeEvent(
                 
                 )
               )
-            ),
+            )
             # column(3, radioButtons(
             #   "sc_curve_method",
             #   label    = "Curve Method",
@@ -861,17 +861,30 @@ observeEvent(
             #   selected = "Frequentist",
             #   inline   = TRUE
             # )),
+            # column(4, uiOutput("sc_antigen_selector")),
+            # column(4, uiOutput("sc_source_selector"))
+          ),
+          fluidRow(
             column(3, uiOutput("sc_antigen_selector")),
-            column(3, uiOutput("sc_source_selector"))
+            column(3, uiOutput("sc_source_selector")),
+            
+            # Plate selector (Frequentist only) --
+            column(
+              3,
+              conditionalPanel(
+                condition = "input.sc_curve_method == 'Frequentist'",
+                uiOutput("sc_plate_selector")
+              )
+            )
           ),
 
           # ── Row 2: Plate selector (Frequentist only) ──
-          conditionalPanel(
-            condition = "input.sc_curve_method == 'Frequentist'",
-            fluidRow(
-              column(3, uiOutput("sc_plate_selector"))
-            )
-          ),
+          # conditionalPanel(
+          #   condition = "input.sc_curve_method == 'Frequentist'",
+          #   fluidRow(
+          #     column(3, uiOutput("sc_plate_selector"))
+          #   )
+          # ),
 
           fluidRow(
             column(3, actionButton("show_comparisions",


### PR DESCRIPTION
Adjust UI CSS for radio-card groups: add bottom margins to radio labels, a label group rule, and justify-content to radio cards to improve spacing and alignment. In std_curver_ui.R, move the Frequentist plate selector into the same fluidRow as antigen/source selectors using a conditionalPanel, removing the previous separate conditionalRow (now commented out) and tidying layout. These changes improve visual spacing and ensure the plate selector appears inline only when the Frequentist method is selected.