### PR TITLE
Support 'partially completed' Bayes status

### DIFF
--- a/src/bayes_concentration_functions.R
+++ b/src/bayes_concentration_functions.R
@@ -1122,6 +1122,7 @@ createStatusBadge <- function(method,
       "completed" = "#28a745",
       "failed"    = "#dc3545",
       "not begun" = "#dc3545",
+      "partially completed" = "#6f42c1",
       "#999999"
     )
 
@@ -1138,7 +1139,7 @@ createStatusBadge <- function(method,
     coverage <- bayes_status$coverage
     cov_label <- if (!is.null(coverage) && !is.na(coverage$n_total) && coverage$n_total > 0L) {
       pct <- round(100 * coverage$n_done / coverage$n_total)
-      col <- if (coverage$n_done == coverage$n_total) "#155724" else "#856404"
+     col <- if (coverage$n_done == coverage$n_total) "#155724" else "#ffffff"#"#856404"
       tags$small(
         style = paste0("font-weight:normal; display:block; margin-top:2px; color:", col, ";"),
         sprintf("%d / %d experiments", coverage$n_done, coverage$n_total)
@@ -1196,6 +1197,20 @@ createStatusBadge <- function(method,
           if (!is.null(ts_label)) tags$small(style = "font-weight:normal; opacity:0.85;",
                                               paste0("Last: ", ts_label)),
           via_label,
+          cov_label
+        )
+      },
+      # add partial completion status
+      "partially completed" = {
+        ts <- bayes_status$timestamp
+        ts_label <- if (!is.null(ts) && !is.na(ts)) {
+          format(as.POSIXct(ts, tz = "UTC"), "%b %d at %I:%M %p")
+        } else { NULL }
+        tagList(
+          tags$i(class = "fa fa-layer-group"), " Partially Completed",
+          if (!is.null(ts_label)) tags$br(),
+          if (!is.null(ts_label)) tags$small(style = "font-weight:normal; opacity:0.85;",
+                                             paste0("Last: ", ts_label)),
           cov_label
         )
       },

--- a/src/std_curver_ui.R
+++ b/src/std_curver_ui.R
@@ -208,13 +208,16 @@ get_bayes_calc_status <- function(conn, project_id, study, experiment = NULL,
     ))
   }
   if (job$status == "completed") {
+    
     return(list(
       status     = "completed",
       timestamp  = job$completed_at %||% job$updated_at,
       job_id     = job$job_id,
       covered_by = covered_by
     ))
+    
   }
+    
   if (job$status %in% c("failed", "error", "timed_out")) {
     return(list(
       status     = "failed",
@@ -226,6 +229,7 @@ get_bayes_calc_status <- function(conn, project_id, study, experiment = NULL,
     ))
   }
 
+  #.check_coverage_or_not_begun(covered_by)
   list(status = "not begun", covered_by = covered_by)
 }
 
@@ -2260,6 +2264,16 @@ observeEvent(
           get_study_bayes_coverage(conn, proj, stdy),
           error = function(e) NULL)
 
+         # # # when Bayes curves covers only a subset of experiments it is partially completed
+         if (identical(study_st$status, "not begun")) {
+           cov <- study_st$coverage
+           if (!is.null(cov) &&
+               isTRUE(is.finite(cov$n_total)) && cov$n_total > 0L &&
+               isTRUE(is.finite(cov$n_done))  && cov$n_done  < cov$n_total) {
+             study_st$status <- "partially completed"
+           }
+         }
+        
         # Attach per-source coverage to antigen badge (multi-source studies only)
         antg_st$sources <- tryCatch(
           get_antigen_source_coverage(conn, proj, stdy, expt, antg),


### PR DESCRIPTION
Add handling and UI for a new "partially completed" Bayes calculation status. Updates include: adding a status color (#6f42c1) and badge content (icon, timestamp and coverage label) in src/bayes_concentration_functions.R; change the coverage text color for incomplete coverage to white; and update logic in src/std_curver_ui.R to return/derive partial status when only a subset of experiments are covered. These changes make it possible to surface partial Bayes computation progress in the UI.