### PR TITLE
Add RData bundle download and SQL join keys

### DIFF
--- a/src/db_functions.R
+++ b/src/db_functions.R
@@ -2048,7 +2048,7 @@ gate_class_pcov, best_glance_all_id, feature, norm_assay_response, raw_robust_co
 
 ## Adds the Bayesian concentration and SE to the dataframe
 fetch_best_sampl_se_with_bayes <- function(study_accession, experiment_accession, project_id, conn) {
-  query <- glue("SELECT
+  query <- glue("SELECT 
     -- Identifiers
     bse.best_sample_se_all_id,
     bse.project_id,
@@ -2121,6 +2121,9 @@ LEFT JOIN madi_results.bayes_samples bs
     AND bse.well                  = bs.well
     AND bse.antigen               = bs.antigen
     AND bse.feature               = bs.feature
+    AND bse.timeperiod            = bs.timeperiod    
+    AND bse.dilution              = bs.dilution    
+	  AND bse.wavelength 			      = bs.wavelength
 WHERE bse.project_id           = {project_id}
   AND bse.study_accession      = '{study_accession}'
   AND bse.experiment_accession = '{experiment_accession}'

--- a/src/load_previous_stored_data.R
+++ b/src/load_previous_stored_data.R
@@ -1,3 +1,29 @@
+# RData Bundle download 
+coerce_int64_to_character <- function(df) {
+  if (is.null(df) || !is.data.frame(df)) return(df)
+  df[] <- lapply(df, function(col) {
+    if (inherits(col, "integer64")) bit64::as.character.integer64(col) else col
+  })
+  df
+}
+
+output$download_rdata_bundle <- downloadHandler(
+  filename = function() {
+    paste0(
+      input$readxMap_study_accession, "_",
+      input$readxMap_experiment_accession, ".RData"
+    )
+  },
+  content = function(file) {
+    plates     <- coerce_int64_to_character(stored_plates_data$stored_header)
+    standards  <- coerce_int64_to_character(stored_plates_data$stored_standard)
+    blanks     <- coerce_int64_to_character(stored_plates_data$stored_buffer)
+    controls   <- coerce_int64_to_character(stored_plates_data$stored_control)
+    samples    <- coerce_int64_to_character(stored_plates_data$stored_sample)
+    sample_qc  <- coerce_int64_to_character(stored_plates_data$stored_best_sample_se)
+    save(plates, standards, blanks, controls, samples, sample_qc, file = file)
+  }
+)
 
 
 # Function to create download handler for each button

--- a/src/ui_handler.R
+++ b/src/ui_handler.R
@@ -575,6 +575,13 @@ output$dynamic_data_ui <- renderUI({
         label = "Refresh Data",
         icon = icon("refresh")
       ),
+      downloadButton(
+        outputId = "download_rdata_bundle",
+        label = "R Data Bundle",
+        icon = icon("download")
+      ) |> tagAppendAttributes(
+        title = "Downloads an RData file containing plates, standards, blanks, controls, samples, and sample QC dataframes."
+      ),
     tabsetPanel(
       id = "dataCollapse",
       tabPanel(


### PR DESCRIPTION
Add a download handler and UI button to export an RData bundle containing plates, standards, blanks, controls, samples, and sample QC. Introduce coerce_int64_to_character to convert integer64 columns to character before saving to avoid serialization issues. Enhance fetch_best_sampl_se_with_bayes SQL to include additional join conditions (timeperiod, dilution, wavelength) to ensure correct matching between bse and bayes_samples.